### PR TITLE
Fixed #12 - Infinite loop in `LinkedList::population` method

### DIFF
--- a/src/linked_list.cpp
+++ b/src/linked_list.cpp
@@ -4,8 +4,7 @@
 #include <pthread.h>
 #include "linked_list.h"
 
-void LinkedList::Populate(int n, int mInsert, int mDelete,
-                          std::set<int> &insertVals, std::set<int> &deleteVals)
+void LinkedList::Populate(int n)
 {
     std::srand(std::time(nullptr)); // use current time as seed for random generator
     std::set<int> uniqueVals;
@@ -35,26 +34,6 @@ void LinkedList::Populate(int n, int mInsert, int mDelete,
         }
         curr = next;
         length++;
-    }
-
-    // Generate numbers to delete that are already in the linked list
-    while (deleteVals.size() < (std::size_t)(mDelete))
-    {
-        int data = std::rand() % (1 << 16);
-        std::size_t size = uniqueVals.size();
-        uniqueVals.erase(data);
-        if (size != uniqueVals.size()) // if the set size not changed, then the value was in the set
-            deleteVals.insert(data);
-    }
-
-    // Generate numbers to insert that are not already in the linked list
-    while (insertVals.size() < (std::size_t)(mInsert))
-    {
-        int data = std::rand() % (1 << 16);
-        std::size_t size = uniqueVals.size();
-        uniqueVals.insert(data);
-        if (size != uniqueVals.size()) // if the set size changed, then the value was unique
-            insertVals.insert(data);
     }
 }
 

--- a/src/linked_list.h
+++ b/src/linked_list.h
@@ -2,7 +2,6 @@
 #define LINKED_LIST_H
 
 #include <iostream>
-#include <set>
 #include <pthread.h>
 
 class LinkedList
@@ -22,8 +21,7 @@ public:
         }
     }
 
-    void Populate(int n, int mInsert, int mDelete,
-                  std::set<int> &insertVals, std::set<int> &deleteVals);
+    void Populate(int n);
 
     virtual bool Member(int data) = 0;
     virtual bool Insert(int data) = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <fstream>
-#include <set>
 #include <pthread.h>
 #include "linked_list.h"
 #include "threading.h"
@@ -66,9 +65,8 @@ int main(int argc, char **argv)
     }
 
     std::string filename(argv[8]);
-    std::set<int> insertVals, deleteVals;
-    list->Populate(n, m * mInsert, m * mDelete, insertVals, deleteVals);
-    long timeDiff = run_threads(threadCnt, list, insertVals, deleteVals, m, mMember, mInsert, mDelete);
+    list->Populate(n);
+    long timeDiff = run_threads(threadCnt, list, m, mMember, mInsert, mDelete);
     delete list;
 
     return print_time_diff(filename, timeDiff) ? 0 : 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 
 void print_usage()
 {
-    std::cerr << "Usage: ./linked_list <n> <m> <type> <m_Member> <m_Insert> <m_Delete>" << std::endl
+    std::cerr << "Usage: ./main <n> <m> <type> <thread_cnt> <m_Member> <m_Insert> <m_Delete> <filename>" << std::endl
               << "\tn:\t\tnumber of initial elements in the linked list" << std::endl
               << "\tm:\t\tnumber of operations per thread" << std::endl
               << "\ttype:\t\t1 for serial, 2 for mutex, 3 for rwlock" << std::endl

--- a/src/threading.cpp
+++ b/src/threading.cpp
@@ -1,6 +1,5 @@
 #include <iostream>
 #include <chrono>
-#include <set>
 #include <pthread.h>
 #include "linked_list.h"
 #include "threading.h"
@@ -19,32 +18,26 @@ void *thread_func(void *arg)
 
     // Delete
     int mDeleteLocal = (int)(args->mDelete * args->m) / args->threadCnt;
-    int myFirstDeleteIndex = ((int)(args->tid)) * mDeleteLocal;
-    int myLastDeleteIndex = myFirstDeleteIndex + mDeleteLocal;
-    for (int i = myFirstDeleteIndex; i < myLastDeleteIndex; ++i)
+    for (int i = 0; i < mDeleteLocal; ++i)
     {
-        args->list->Remove((*args->deleteVals)[i]);
+        int data = std::rand() % (1 << 16);
+        args->list->Remove(data);
     }
 
     // Insert
     int mInsertLocal = (int)(args->mInsert * args->m) / args->threadCnt;
-    int myFirstInsertIndex = ((int)(args->tid)) * mInsertLocal;
-    int myLastInsertIndex = myFirstInsertIndex + mInsertLocal;
-    for (int i = myFirstInsertIndex; i < myLastInsertIndex; ++i)
+    for (int i = 0; i < mInsertLocal; ++i)
     {
-        args->list->Insert((*args->insertVals)[i]);
+        int data = std::rand() % (1 << 16);
+        args->list->Insert(data);
     }
 
     return NULL;
 }
 
 long run_threads(int threadCnt, LinkedList *list,
-                 std::set<int> &insertVals, std::set<int> &deleteVals,
                  int m, double mMember, double mInsert, double mDelete)
 {
-    std::vector<int> insertValsVec(insertVals.begin(), insertVals.end());
-    std::vector<int> deleteValsVec(deleteVals.begin(), deleteVals.end());
-
     std::chrono::high_resolution_clock::time_point start_time, end_time;
     start_time = std::chrono::high_resolution_clock::now();
 
@@ -53,8 +46,6 @@ long run_threads(int threadCnt, LinkedList *list,
     for (int i = 0; i < threadCnt; ++i)
     {
         args[i].list = list;
-        args[i].insertVals = &insertValsVec;
-        args[i].deleteVals = &deleteValsVec;
         args[i].m = m;
         args[i].mMember = mMember;
         args[i].mInsert = mInsert;

--- a/src/threading.h
+++ b/src/threading.h
@@ -2,16 +2,12 @@
 #define THREADS_H
 
 #include <iostream>
-#include <set>
-#include <vector>
 #include <pthread.h>
 #include "linked_list.h"
 
 typedef struct ThreadArgs
 {
     LinkedList *list;
-    std::vector<int> *insertVals;
-    std::vector<int> *deleteVals;
     int m;
     double mMember;
     double mInsert;
@@ -22,7 +18,6 @@ typedef struct ThreadArgs
 
 void *thread_func(void *arg);
 long run_threads(int threadCnt, LinkedList *list,
-                 std::set<int> &insertVals, std::set<int> &deleteVals,
                  int m, double mMember, double mInsert, double mDelete);
 
 #endif // THREADS_H


### PR DESCRIPTION
- Removed random number generation for insertion and deletion from the `LinkedList::population` method.
- Random numbers will be dynamically generated while performing insertion and deletion within the `thread_func` function.
- Updated the help message given in the `print_usage` function.